### PR TITLE
@cavvia => API now returns timestamps in the ISO8601 format without millisecond precision.

### DIFF
--- a/app/views/content/docs/applications.md
+++ b/app/views/content/docs/applications.md
@@ -85,8 +85,8 @@ user       | User that owns the application. |
 ``` json
 {
   "id" : "...",
-  "created_at" : "2014-08-31T15:05:29.000Z",
-  "updated_at" : "2014-08-31T15:05:29.000Z",
+  "created_at" : "2014-08-31T15:05:29+00:00",
+  "updated_at" : "2014-08-31T15:05:29+00:00",
   "name" : "Test",
   "client_id" : "...",
   "client_secret" : "...",

--- a/app/views/content/docs/http.md
+++ b/app/views/content/docs/http.md
@@ -65,12 +65,12 @@ A JSON document can have keys and values. Typical resources contain a unique "id
 
 #### Timestamps
 
-Most resources also contain a "created_at" and "updated_at" UTC timestamp in the [ISO 8601](http://en.wikipedia.org/wiki/ISO_8601) format.
+Most resources also contain a "created_at" and "updated_at" UTC timestamp in the [ISO 8601](http://en.wikipedia.org/wiki/ISO_8601) format, without millisecond precision.
 
 ``` json
 {
-  "reated_at" : "2010-08-23T14:15:30.000Z",
-  "updated_at" : "2014-08-29T14:25:57.000Z"
+  "reated_at" : "2010-08-23T14:15:30+00:00",
+  "updated_at" : "2014-08-29T14:25:57+00:00"
 }
 ```
 

--- a/app/views/content/docs/user_details.md
+++ b/app/views/content/docs/user_details.md
@@ -32,8 +32,8 @@ user       | Link to the [user](/docs/users) information.         |
 ``` json
 {
   "id" : "52fe4b28c94d114d36000001",
-  "created_at" : "2014-02-14T16:58:17.000Z",
-  "updated_at" : "2014-09-08T13:32:34.000Z",
+  "created_at" : "2014-02-14T16:58:17+00:00",
+  "updated_at" : "2014-09-08T13:32:34+00:00",
   "type" : "User",
   "email" : "user@example.com",
   "birthday" : null,


### PR DESCRIPTION
We always truncate millisecond precision in storage, so we shouldn't try to return it. Both old and new values are correct ISO8601 format though.

For internal reference, see https://github.com/artsy/gravity/pull/8011 and https://github.com/artsy/gravity/pull/8094.
