### PR TITLE
@zamiang => Documented the search API.

### DIFF
--- a/app/controllers/pages_controller.rb
+++ b/app/controllers/pages_controller.rb
@@ -6,7 +6,7 @@ class PagesController < ApplicationController
     filename = Rails.root.join("app/views/content/#{params[:id]}.md")
     @content = Rails.cache.fetch "content/#{params[:id]}/#{File.mtime(filename)}/#{current_user ? current_user.id : nil}" do
       text = File.read(filename)
-      text = text.gsub(/\#\{(?<var> [\w\.,_\/:=]*)\}/x) do
+      text = text.gsub(/\#\{(?<var> [\w\.,_\/:=\+\s\d-]*)\}/x) do
         var = $~[:var]
         if var == 'ArtsyAPI.artsy_api_root'
           ArtsyAPI.artsy_api_root

--- a/app/views/content/docs.md
+++ b/app/views/content/docs.md
@@ -23,3 +23,4 @@
 * [Applications](/docs/applications)
 * [Users](/docs/users)
 * [User Details](/docs/user_details)
+* [Search](/docs/search)

--- a/app/views/content/docs/search.md
+++ b/app/views/content/docs/search.md
@@ -1,0 +1,58 @@
+[Documentation](/docs) &gt; Resources &gt; Search
+
+## Search API
+
+Search for anything on Artsy.
+
+#### Retrieving Search Results
+
+Search for anything by following the [search](#{ArtsyAPI.artsy_api_root}/search) link from [root](#{ArtsyAPI.artsy_api_root}) with a query parameter.
+
+```
+curl -v "#{ArtsyAPI.artsy_api_root}/search?q=Andy+Warhol" -H "X-XAPP-Token:#{xapp_token}"
+```
+
+The response is a [paginated result](/docs/pagination) with embedded search results.
+
+## Search Result JSON Format
+
+#{modelref://SearchResult}
+
+#### Possible Types
+
+Type          | Resource                                           |
+-------------:|:---------------------------------------------------|
+Artist        | An Artsy [artist](/docs/artists).                  |
+Artwork       | An Artsy [artwork](/docs/artworks).                |
+Profile       | An Artsy [profile](/docs/profiles).                |
+Gene          | An Artsy [gene](/docs/genes).                      |
+
+The API will also return search results with a "null" value for "type". Those are not supported by the API (yet) and may include features, posts or shows.
+
+#### Links
+
+Key        | Target                                          |
+----------:|:------------------------------------------------|
+self       | The resource found, when available.             |
+thumbnail  | Image thumbnail, when available.                |
+permalink  | An external location on the artsy.net website.  |
+
+``` alert[warning]
+You can follow the "self" link on each individual search result, however because of delays in indexing and content restrictions there's no guarantee that those links will always return a resource. Notably, only a subset of artworks is available via the API, whereas search returns all content published on artsy.net.
+```
+
+#### Advanced Search
+
+You can leverage the filtering capabilities of [Google Custom Search](https://developers.google.com/custom-search/docs/structured_search) that provides the back-end for the Artsy search API.
+
+For example, only search for artists by specifying an "artist" open-graph type with `more:pagemap:metatags-og_type:artist`.
+
+```
+curl -v "#{ArtsyAPI.artsy_api_root}/search?q=Andy+Warhol+more:pagemap:metatags-og_type:artist" -H "X-XAPP-Token:#{xapp_token}"
+```
+
+#### Example
+
+``` json
+#{resource://search/q=Andy Warhol}
+```

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -24,7 +24,8 @@ Rails.application.routes.draw do
     :status,
     :users,
     :user_details,
-    :markdown
+    :markdown,
+    :search
   ].each do |page|
     get "/docs/#{page}", to: 'pages#show', id: "docs/#{page}"
   end


### PR DESCRIPTION
Documented the new search API.

I decided not to expose any special query parameters for filtering and just let the clients specify that. So if someone wants to search for artists only, they can add `more:pagemap:metatags-og_type:artist` to the search query themselves. There're too many combinations of things possible with Google Custom Search, I feel like we're not adding any value by wrapping it up.
