### PR TITLE
@dblock => Fix: always making markdown typos that creates ems.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,5 @@
+sudo: false
+
 before_install:
   - "export DISPLAY=:99.0"
   - "sh -e /etc/init.d/xvfb start"

--- a/app/views/content/docs/artists.md
+++ b/app/views/content/docs/artists.md
@@ -30,7 +30,7 @@ Follow the "artists" link from an [artwork](/docs/artworks), which calls this en
 
 #### Retrieving Similar Artists
 
-Artsy continuously computes a K-nearest-neighbor graph for artists using data from the [Art Genome Project](https://artsy.net/about/the-art-genome-project). Retrieve artists similar to another artist by following the "similar_artists" or the "similar_contemporary_artists" links in an artist resource, which calls this endpoint with the `similar_to_artist_id` parameter and an optional `similarity_type` value. The response is a non-paginated set of similar artists or similar contemporary artists, respectively.
+Artsy continuously computes a K-nearest-neighbor graph for artists using data from the [Art Genome Project](https://artsy.net/about/the-art-genome-project). Retrieve artists similar to another artist by following the "similar\_artists" or the "similar\_contemporary\_artists" links in an artist resource, which calls this endpoint with the `similar_to_artist_id` parameter and an optional `similarity_type` value. The response is a non-paginated set of similar artists or similar contemporary artists, respectively.
 
 ## Artist JSON Format
 
@@ -38,15 +38,15 @@ Artsy continuously computes a K-nearest-neighbor graph for artists using data fr
 
 #### Links
 
-Key                            | Target                                          |
-------------------------------:|:------------------------------------------------|
-self                           | The artist resource.                            |
-thumbnail                      | Default image thumbnail.                        |
-image:self                     | Curied image location.                          |
-permalink                      | An external location on the artsy.net website.  |
-artworks                       | All artist's [artworks](/docs/artworks).        |
-similar_artists                | Artists similar to this artist.                 |
-similar_contemporary_artists   | Contemporary artists similar to this artist.    |
+Key                              | Target                                          |
+--------------------------------:|:------------------------------------------------|
+self                             | The artist resource.                            |
+thumbnail                        | Default image thumbnail.                        |
+image:self                       | Curied image location.                          |
+permalink                        | An external location on the artsy.net website.  |
+artworks                         | All artist's [artworks](/docs/artworks).        |
+similar\_artists                 | Artists similar to this artist.                 |
+similar\_contemporary\_artists   | Contemporary artists similar to this artist.    |
 
 #### Example
 

--- a/app/views/content/docs/artworks.md
+++ b/app/views/content/docs/artworks.md
@@ -32,7 +32,7 @@ curl -v "#{ArtsyAPI.artsy_api_root}/artworks/{id}" -H "X-XAPP-Token:#{xapp_token
 
 #### Retrieving Similar Artworks
 
-Artsy continuously computes a K-nearest-neighbor graph for artworks using data from the [Art Genome Project](https://artsy.net/about/the-art-genome-project). Retrieve artworks similar to another artwork by following the "similar_artworks" link in an artwork resource, which calls this endpoint with the `similar_to_artwork_id` parameter. The response is a non-paginated set of similar artworks.
+Artsy continuously computes a K-nearest-neighbor graph for artworks using data from the [Art Genome Project](https://artsy.net/about/the-art-genome-project). Retrieve artworks similar to another artwork by following the "similar\_artworks" link in an artwork resource, which calls this endpoint with the `similar\_to\_artwork_id` parameter. The response is a non-paginated set of similar artworks.
 
 ## Artwork JSON Format
 
@@ -40,16 +40,16 @@ Artsy continuously computes a K-nearest-neighbor graph for artworks using data f
 
 #### Links
 
-Key               | Target                                           |
------------------:|:-------------------------------------------------|
-self              | The artwork resource.                            |
-thumbnail         | Default image thumbnail.                         |
-image:self        | Curied image location.                           |
-permalink         | An external location on the artsy.net website.   |
-partner           | [Partner](/docs/partners) that owns the artwork. |
-artists           | Artwork's [Artists](/docs/artists).              |
-genes             | Artwork's [Genes](/docs/genes).                  |
-similar_artworks  | Artwork similar to the artwork.                  |
+Key                | Target                                           |
+------------------:|:-------------------------------------------------|
+self               | The artwork resource.                            |
+thumbnail          | Default image thumbnail.                         |
+image:self         | Curied image location.                           |
+permalink          | An external location on the artsy.net website.   |
+partner            | [Partner](/docs/partners) that owns the artwork. |
+artists            | Artwork's [Artists](/docs/artists).              |
+genes              | Artwork's [Genes](/docs/genes).                  |
+similar\_artworks  | Artwork similar to the artwork.                  |
 
 #### Embedded Collections
 

--- a/app/views/content/docs/http.md
+++ b/app/views/content/docs/http.md
@@ -65,7 +65,7 @@ A JSON document can have keys and values. Typical resources contain a unique "id
 
 #### Timestamps
 
-Most resources also contain a "created_at" and "updated_at" UTC timestamp in the [ISO 8601](http://en.wikipedia.org/wiki/ISO_8601) format, without millisecond precision.
+Most resources also contain a "created\_at" and "updated\_at" UTC timestamp in the [ISO 8601](http://en.wikipedia.org/wiki/ISO_8601) format, without millisecond precision.
 
 ``` json
 {

--- a/app/views/content/docs/markdown.md
+++ b/app/views/content/docs/markdown.md
@@ -5,12 +5,12 @@
 Many content fields in the Artsy API, such as [artist](/docs/artists) bios or [gene](/docs/genes) descriptions, will return data in [markdown format](http://daringfireball.net/projects/markdown/syntax). For example, the description of the "Pop Art" gene includes the following.
 
 ```
-_“The Pop artists did images that anybody walking down Broadway could recognize in a split second—comics, picnic tables, men’s trousers, celebrities, shower curtains, refrigerators, coke bottles—all the great modern things that the Abstract Expressionists tried so hard not to notice at all.” –[Andy Warhol](/artist/andy-warhol)_
+**“The Pop artists did images that anybody walking down Broadway could recognize in a split second—comics, picnic tables, men’s trousers, celebrities, shower curtains, refrigerators, coke bottles—all the great modern things that the Abstract Expressionists tried so hard not to notice at all.” – [Andy Warhol](/artist/andy-warhol)**
 ```
 
-Once rendered, this becomes a quoted italic text.
+Once rendered, this becomes a quoted bold text.
 
-_“The Pop artists did images that anybody walking down Broadway could recognize in a split second—comics, picnic tables, men’s trousers, celebrities, shower curtains, refrigerators, coke bottles—all the great modern things that the Abstract Expressionists tried so hard not to notice at all.” –[Andy Warhol](https://artsy.net/artist/andy-warhol)_
+**“The Pop artists did images that anybody walking down Broadway could recognize in a split second—comics, picnic tables, men’s trousers, celebrities, shower curtains, refrigerators, coke bottles—all the great modern things that the Abstract Expressionists tried so hard not to notice at all.” – [Andy Warhol](https://artsy.net/artist/andy-warhol)**
 
 ``` alert[info]
 Some internal links within the markdown content may be relative to https://artsy.net.

--- a/spec/features/docs_spec.rb
+++ b/spec/features/docs_spec.rb
@@ -19,6 +19,9 @@ describe 'Docs' do
       it 'displays a breadcrumb back to docs' do
         expect(page).to have_css "a[href='/docs']"
       end
+      it 'does not include any italics' do
+        expect(page).to_not have_css 'em'
+      end
     end
   end
 end


### PR DESCRIPTION
Closes https://github.com/artsy/doppler/issues/74.
