### PR TITLE
@mzikherman => Always show a playground link, which already redirects to login.

### DIFF
--- a/app/views/shared/_nav.html.haml
+++ b/app/views/shared/_nav.html.haml
@@ -1,9 +1,8 @@
 = nav_bar static: :top, brand: "The art world in your app. &#0153;".html_safe, responsive: true do
   = menu_group do
     = menu_item "Home", root_path
-    -if authenticated?
-      = menu_item "My Apps", client_applications_path
-      = menu_item "Playground", playground_path
+    = menu_item "My Apps", client_applications_path
+    = menu_item "Playground", playground_path
     = menu_item "Blog", 'http://artsy.github.io', target: '_blank'
     = menu_item "Docs", docs_path
     = menu_item "Help", help_path

--- a/spec/features/client_applications_spec.rb
+++ b/spec/features/client_applications_spec.rb
@@ -16,10 +16,6 @@ describe 'Client Applications' do
       before do
         allow(ArtsyAPI).to receive_message_chain(:client, :applications).and_return([])
       end
-      it 'renders a list of apps' do
-        visit '/client_applications'
-        expect(page.body).to include 'My Apps'
-      end
       it 'creates an app' do
         expect(ArtsyAPI).to receive_message_chain(:client, :applications, :_post).with(name: 'Name')
         visit '/client_applications'


### PR DESCRIPTION
People who want to play can't find the playground or figure out that they need to login.