### PR TITLE
@starsirius => Fix: open-redirect for full relative URLs.

### DIFF
--- a/app/helpers/open_redirect_helper.rb
+++ b/app/helpers/open_redirect_helper.rb
@@ -6,7 +6,7 @@ module OpenRedirectHelper
       parsed_url = root_url + redirect_uri
       return nil if parsed_url.is_a?(URI::Data)
       return nil unless parsed_url.is_a?(URI::HTTP)
-      return parsed_url.to_s if parsed_url.host.nil?
+      return parsed_url.to_s if parsed_url.host.nil? && parsed_url.relative?
       return parsed_url.to_s if parsed_url.scheme == request.scheme && parsed_url.host == request.host && parsed_url.port == request.port
       nil
     rescue URI::InvalidURIError

--- a/spec/features/client_applications_spec.rb
+++ b/spec/features/client_applications_spec.rb
@@ -31,11 +31,13 @@ describe 'Client Applications' do
         before do
           allow(ArtsyAPI).to receive_message_chain(:client, :applications, :_post)
         end
-        it 'does not have an open redirect' do
-          visit '/client_applications/new?redirect_uri=http://google.com'
-          fill_in 'Name', with: 'Name'
-          click_button 'Save'
-          expect(current_url).to end_with '/client_applications'
+        ['http://google.com', 'http:/google.com'].each do |url|
+          it "is not vulnerable to an open redirect to #{url}" do
+            visit "/client_applications/new?redirect_uri=#{url}"
+            fill_in 'Name', with: 'Name'
+            click_button 'Save'
+            expect(current_url).to end_with '/client_applications'
+          end
         end
         it 'redirects to a relative uri' do
           visit '/client_applications/new?redirect_uri=/docs'


### PR DESCRIPTION
This is a nasty one, you can have a URL with a single slash, eg. `http:/google.com`, which will produce a `nil` host, but will be absolute (not relative). We have to make sure we're only redirecting within our application.