### PR TITLE
@ashkan18 => Fix: auth open redirect.

### DIFF
--- a/app/controllers/session_controller.rb
+++ b/app/controllers/session_controller.rb
@@ -17,10 +17,9 @@ class SessionController < ApplicationController
     )
     warden.set_user user
 
-    redirect_uri = session[:redirect_uri]
-    session[:redirect_uri] = nil if redirect_uri
+    redirect_to redirect_path
 
-    redirect_to redirect_uri || '/'
+    session[:redirect_uri] = nil
   end
 
   def destroy
@@ -33,5 +32,12 @@ class SessionController < ApplicationController
 
   def auth_hash
     @auth_hash ||= Hashie::Mash.new(request.env['omniauth.auth'])
+  end
+
+  def redirect_path
+    url = session[:redirect_uri]
+    URI.parse(url).path
+  rescue URI::InvalidURIError
+    '/'
   end
 end

--- a/spec/controllers/session_controller_spec.rb
+++ b/spec/controllers/session_controller_spec.rb
@@ -1,0 +1,52 @@
+require 'spec_helper'
+
+RSpec.describe SessionController, type: :controller do
+  describe 'GET #new' do
+    context 'unauthenticated' do
+      before do
+        allow(subject).to receive(:authenticated?).and_return false
+      end
+      it 'stores redirect_uri' do
+        get :new, redirect_uri: '/applications'
+        expect(session[:redirect_uri]).to eq '/applications'
+      end
+    end
+    context 'authenticated' do
+      before do
+        allow(subject).to receive(:authenticated?).and_return true
+      end
+      it 'redirects to root' do
+        get :new, redirect_uri: '/applications'
+        expect(response).to redirect_to('/')
+      end
+    end
+  end
+  describe 'GET #destroy' do
+    it 'redirect to gravity API logout page' do
+      get :destroy
+      expect(response).to redirect_to('http://localhost:3000/users/sign_out?redirect_uri=http%3A%2F%2Ftest.host%2F')
+    end
+  end
+  describe 'POST #create' do
+    let(:warden) { double(Warden::Manager) }
+    before do
+      expect(subject).to receive(:warden).and_return(warden)
+      expect(warden).to receive(:set_user)
+    end
+    it 'redirects' do
+      session[:redirect_uri] = '/applications'
+      post :create, provider: 'artsy'
+      expect(response).to redirect_to('http://test.host/applications')
+    end
+    it 'does not make an open redirect' do
+      session[:redirect_uri] = 'http://bad.stuff/applications'
+      post :create, provider: 'artsy'
+      expect(response).to redirect_to('http://test.host/applications')
+    end
+    it 'defaults to / with no redirect' do
+      session[:redirect_uri] = nil
+      post :create, provider: 'artsy'
+      expect(response).to redirect_to('http://test.host/')
+    end
+  end
+end


### PR DESCRIPTION
This is an open redirect described in an internal Trello [here](https://trello.com/c/pqknAkIK/89-open-redirect-at-https-developers-artsy-net). You can try it with [this link](https://developers.artsy.net/sign_in?redirect_uri=http://attacker.com:%23@developers.artsy.net/x) which causes a redirect to attacker.com after a successful auth. 

The fix is the one suggested in the [OWASP docs](https://www.owasp.org/index.php/Ruby_on_Rails_Cheatsheet#Redirects_and_Forwards) to only allow relative redirects. 

A similar problem has already been fixed in Gravity (the Artsy internal API), [here](https://github.com/artsy/gravity/pull/10079), but it was much more involved since it's an auth provider as well.