### PR TITLE
Update docs to match image link coming back from API

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -48,7 +48,7 @@ ARTSY_API_CLIENT_SECRET=...
 
 Run `foreman start`.
 
-Navigate to http://localhost:5000.
+Navigate to [http://localhost:5000](http://localhost:5000).
 
 #### Write Tests
 

--- a/app/views/content/docs/artists.md
+++ b/app/views/content/docs/artists.md
@@ -42,7 +42,7 @@ Key                              | Target                                       
 --------------------------------:|:------------------------------------------------|
 self                             | The artist resource.                            |
 thumbnail                        | Default image thumbnail.                        |
-image:self                       | Curied image location.                          |
+image                            | Curied image location.                          |
 permalink                        | An external location on the artsy.net website.  |
 artworks                         | All artist's [artworks](/docs/artworks).        |
 similar\_artists                 | Artists similar to this artist.                 |

--- a/app/views/content/docs/artworks.md
+++ b/app/views/content/docs/artworks.md
@@ -46,7 +46,7 @@ Key                | Target                                           |
 ------------------:|:-------------------------------------------------|
 self               | The artwork resource.                            |
 thumbnail          | Default image thumbnail.                         |
-image:self         | Curied image location.                           |
+image              | Curied image location.                           |
 permalink          | An external location on the artsy.net website.   |
 partner            | [Partner](/docs/partners) that owns the artwork. |
 artists            | Artwork's [Artists](/docs/artists).              |

--- a/app/views/content/docs/genes.md
+++ b/app/views/content/docs/genes.md
@@ -29,7 +29,7 @@ Key                | Target                                                     
 ------------------:|:----------------------------------------------------------------|
 self               | The gene resource.                                              |
 thumbnail          | Default image thumbnail.                                        |
-image:self         | Curied image location.                                          |
+image              | Curied image location.                                          |
 permalink          | An external location on the artsy.net website.                  |
 artists            | All [artists](/docs/artists) that have this gene.               |
 artworks           | Public domain [artworks](/docs/artworks) that have this gene.   |

--- a/app/views/content/docs/shows.md
+++ b/app/views/content/docs/shows.md
@@ -39,7 +39,7 @@ Key        | Target                                          |
 ----------:|:------------------------------------------------|
 self       | The show resource.                              |
 thumbnail  | Default image thumbnail.                        |
-image:self | Curied image location.                          |
+image      | Curied image location.                          |
 permalink  | An external location on the artsy.net website.  |
 partner    | Show [partner](/docs/partners).                 |
 artworks   | Show [artworks](/docs/artworks).                |


### PR DESCRIPTION
# Changes
To simplify access `image` reference of some of our models we have removed `:ref` from it. Before, using [Hyperclient](https://github.com/codegram/hyperclient) we had to access `image` using `client['image:self']` now we can simply say `client.image`.