### PR TITLE
Fix heroku deploy, Uglifier::Error: Unexpected token.

### DIFF
--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -23,7 +23,7 @@ Rails.application.configure do
   config.serve_static_files = true
 
   # Compress JavaScripts and CSS.
-  config.assets.js_compressor = :uglifier
+  config.assets.js_compressor = Uglifier.new(harmony: true)
   # config.assets.css_compressor = :sass
 
   # Do not fallback to assets pipeline if a precompiled asset is missed.


### PR DESCRIPTION
See https://dashboard.heroku.com/apps/doppler-staging/activity/builds/648c77cd-2834-4933-b877-f9ebcbb876f9

Reproduced with `RAILS_ENV=production rake assets:precompile`.

```
rake aborted!
       Uglifier::Error: Unexpected token: keyword (const). To use ES6 syntax, harmony mode must be enabled with Uglifier.new(:harmony => true).
```

Fix from https://github.com/rails/webpacker/issues/1285#issuecomment-367753761