### PR TITLE
Fix: twitter link HTTPs and @artsyopensource and other minor fixes

### DIFF
--- a/app/assets/javascripts/playground.js.coffee
+++ b/app/assets/javascripts/playground.js.coffee
@@ -16,11 +16,9 @@ $ ->
       SwaggerUIBundle.plugins.DownloadUrl
     ],
     layout: "StandaloneLayout",
-    configs: {
-      preFetch: (req) ->
-        req.headers["X-Access-Token"] = options.access_token
-        return req
-    }
+    requestInterceptor: (req) =>
+      req.headers["X-Access-Token"] = options.access_token
+      return req
   })
 
   window.ui = ui

--- a/app/assets/stylesheets/playground.css
+++ b/app/assets/stylesheets/playground.css
@@ -2,15 +2,3 @@
  *= require swagger-ui-dist
  */
 
-.swagger-ui-wrap {
-  max-width: none !important;
-  font-family: arial, sans-serif;
-}
-
-#resources {
-  padding: 10px 0px;
-}
-
-#message-bar {
-  text-align: center;
-}

--- a/app/views/playground/index.html.haml
+++ b/app/views/playground/index.html.haml
@@ -5,7 +5,7 @@
     %h1 Playground
     Try out some APIs.
 
-.swagger-section
-  #swagger-ui
+  .swagger-section
+    #swagger-ui
 
 = javascript_include_tag 'playground'

--- a/app/views/shared/_footer.html.haml
+++ b/app/views/shared/_footer.html.haml
@@ -12,4 +12,4 @@
   =link_to 'Security', 'https://artsy.net/security', target: '_blank'
   |
   =link_to image_tag('blacktocat-16.png', border: 0), 'https://github.com/artsy/doppler', target: '_blank'
-  =link_to image_tag('bird_blue_16.png', boder: 0), 'http://twitter.com/artsy'
+  =link_to image_tag('bird_blue_16.png', boder: 0), 'https://twitter.com/artsyopensource'


### PR DESCRIPTION
Lets point the dev docs to the @artsyopensource twitter. This appears at the bottom of documentation pages on developers.artsy.net.

![screen shot 2018-10-30 at 3 13 57 pm](https://user-images.githubusercontent.com/542335/47743886-73a08d00-dc56-11e8-82a0-75a168440190.png)

Fixup layout, now well aligned.

Before:

![screen shot 2018-10-30 at 3 29 29 pm](https://user-images.githubusercontent.com/542335/47744817-a21f6780-dc58-11e8-9038-b16bdeb00031.png)

After

![screen shot 2018-10-30 at 3 29 36 pm](https://user-images.githubusercontent.com/542335/47744822-a51a5800-dc58-11e8-98e3-87a67cf4a040.png)

