### PR TITLE
@joeyAghion => Followup on k8

### DIFF
--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -82,4 +82,8 @@ Rails.application.configure do
 
   # Use default logging formatter so that PID and timestamp are not suppressed.
   config.log_formatter = ::Logger::Formatter.new
+
+  # Disable serving static files from the `/public` folder by default since
+  # Apache or NGINX already handles this.
+  config.serve_static_files = ENV['RAILS_SERVE_STATIC_FILES'].present?
 end

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -50,6 +50,12 @@ Rails.application.configure do
   # Use a different logger for distributed setups.
   # config.logger = ActiveSupport::TaggedLogging.new(SyslogLogger.new)
 
+  if ENV['RAILS_LOG_TO_STDOUT'].present?
+    logger           = ActiveSupport::Logger.new(STDOUT)
+    logger.formatter = config.log_formatter
+    config.logger    = ActiveSupport::TaggedLogging.new(logger)
+  end
+
   # Use a different cache store in production.
   config.cache_store = :redis_store, ENV['REDIS_URL']
 

--- a/config/environments/staging.rb
+++ b/config/environments/staging.rb
@@ -82,4 +82,8 @@ Rails.application.configure do
 
   # Use default logging formatter so that PID and timestamp are not suppressed.
   config.log_formatter = ::Logger::Formatter.new
+
+  # Disable serving static files from the `/public` folder by default since
+  # Apache or NGINX already handles this.
+  config.serve_static_files = ENV['RAILS_SERVE_STATIC_FILES'].present?
 end

--- a/config/environments/staging.rb
+++ b/config/environments/staging.rb
@@ -50,6 +50,12 @@ Rails.application.configure do
   # Use a different logger for distributed setups.
   # config.logger = ActiveSupport::TaggedLogging.new(SyslogLogger.new)
 
+  if ENV['RAILS_LOG_TO_STDOUT'].present?
+    logger           = ActiveSupport::Logger.new(STDOUT)
+    logger.formatter = config.log_formatter
+    config.logger    = ActiveSupport::TaggedLogging.new(logger)
+  end
+
   # Use a different cache store in production.
   config.cache_store = :redis_store, ENV['REDIS_URL']
 

--- a/hokusai/production.yml
+++ b/hokusai/production.yml
@@ -22,11 +22,7 @@ spec:
       containers:
         - name: doppler-web
           env:
-            - name: RAILS_ENV
-              value: production
             - name: RAILS_SERVE_STATIC_FILES
-              value: 'true'
-            - name: RAILS_LOG_TO_STDOUT
               value: 'true'
             - name: TRACE_AGENT_HOSTNAME
               valueFrom:

--- a/hokusai/production.yml
+++ b/hokusai/production.yml
@@ -22,8 +22,6 @@ spec:
       containers:
         - name: doppler-web
           env:
-            - name: RAILS_SERVE_STATIC_FILES
-              value: 'true'
             - name: TRACE_AGENT_HOSTNAME
               valueFrom:
                 fieldRef:

--- a/hokusai/staging.yml
+++ b/hokusai/staging.yml
@@ -22,10 +22,6 @@ spec:
       containers:
         - name: doppler-web
           env:
-            - name: RAILS_ENV
-              value: production
-            - name: RAILS_SERVE_STATIC_FILES
-              value: 'true'
             - name: TRACE_AGENT_HOSTNAME
               valueFrom:
                 fieldRef:

--- a/hokusai/staging.yml
+++ b/hokusai/staging.yml
@@ -26,8 +26,6 @@ spec:
               value: production
             - name: RAILS_SERVE_STATIC_FILES
               value: 'true'
-            - name: RAILS_LOG_TO_STDOUT
-              value: 'true'
             - name: TRACE_AGENT_HOSTNAME
               valueFrom:
                 fieldRef:


### PR DESCRIPTION
Followup to @joeyAghion's notes on https://github.com/artsy/doppler/pull/154

Support `RAILS_LOG_TO_STDOUT` and `RAILS_SERVE_STATIC_FILES`, inspired by https://github.com/artsy/diffusion. Note that it doesn't seem like we do this correctly in https://github.com/artsy/volt.

I already ran `hokusai staging/production env set` for these.