### PR TITLE
#migration move from ELB to ingress controller 

### DIFF
--- a/hokusai/production.yml
+++ b/hokusai/production.yml
@@ -93,10 +93,10 @@ metadata:
   name: doppler
 spec:
   rules:
-  - host: developers.artsy.net
-    http:
-      paths:
-      - path: /
-        backend:
-          serviceName: doppler-web
-          servicePort: http
+    - host: developers.artsy.net
+      http:
+        paths:
+          - path: /
+            backend:
+              serviceName: doppler-web
+              servicePort: http

--- a/hokusai/production.yml
+++ b/hokusai/production.yml
@@ -85,3 +85,18 @@ spec:
     component: web
   sessionAffinity: None
   type: LoadBalancer
+
+---
+apiVersion: extensions/v1beta1
+kind: Ingress
+metadata:
+  name: doppler
+spec:
+  rules:
+  - host: developers.artsy.net
+    http:
+      paths:
+      - path: /
+        backend:
+          serviceName: doppler-web
+          servicePort: http

--- a/hokusai/staging.yml
+++ b/hokusai/staging.yml
@@ -54,6 +54,7 @@ spec:
                   operator: In
                   values:
                     - foreground
+
 ---
 apiVersion: v1
 kind: Service
@@ -64,12 +65,6 @@ metadata:
     layer: application
   name: doppler-web
   namespace: default
-  annotations:
-    service.beta.kubernetes.io/aws-load-balancer-ssl-cert: {{ artsyNetWildcardSSLCert }}
-    service.beta.kubernetes.io/aws-load-balancer-backend-protocol: "http"
-    service.beta.kubernetes.io/aws-load-balancer-ssl-ports: "443"
-    service.beta.kubernetes.io/aws-load-balancer-cross-zone-load-balancing-enabled: "true"
-    service.beta.kubernetes.io/aws-load-balancer-connection-draining-enabled: "true"
 spec:
   ports:
     - port: 443
@@ -84,5 +79,19 @@ spec:
     app: doppler
     layer: application
     component: web
-  sessionAffinity: None
-  type: LoadBalancer
+  type: ClusterIP
+
+---
+apiVersion: extensions/v1beta1
+kind: Ingress
+metadata:
+  name: doppler-virtual-host-ingress
+spec:
+  rules:
+  - host: developers-staging.artsy.net
+    http:
+      paths:
+      - path: /
+        backend:
+          serviceName: doppler-web
+          servicePort: 80

--- a/hokusai/staging.yml
+++ b/hokusai/staging.yml
@@ -84,10 +84,10 @@ metadata:
   name: doppler
 spec:
   rules:
-  - host: developers-staging.artsy.net
-    http:
-      paths:
-      - path: /
-        backend:
-          serviceName: doppler-web
-          servicePort: http
+    - host: developers-staging.artsy.net
+      http:
+        paths:
+          - path: /
+            backend:
+              serviceName: doppler-web
+              servicePort: http

--- a/hokusai/staging.yml
+++ b/hokusai/staging.yml
@@ -67,10 +67,6 @@ metadata:
   namespace: default
 spec:
   ports:
-    - port: 443
-      protocol: TCP
-      name: https
-      targetPort: 8080
     - port: 80
       protocol: TCP
       name: http
@@ -85,7 +81,7 @@ spec:
 apiVersion: extensions/v1beta1
 kind: Ingress
 metadata:
-  name: doppler-virtual-host-ingress
+  name: doppler
 spec:
   rules:
   - host: developers-staging.artsy.net
@@ -94,4 +90,4 @@ spec:
       - path: /
         backend:
           serviceName: doppler-web
-          servicePort: 80
+          servicePort: http


### PR DESCRIPTION
Depends on https://github.com/artsy/substance/pull/169

When migrating services to use an [Ingress Resource](https://kubernetes.io/docs/concepts/services-networking/ingress/#the-ingress-resource) we should first leave the existing service definition in-place, create the Ingress resource then update Cloudflare DNS to point to it.  We will essentially have one NLB per cluster that everything resolves to.

Nginx Ingress resources are effectively virtual hosts - and the resource supports [annotations](https://kubernetes.github.io/ingress-nginx/user-guide/nginx-configuration/annotations/) to customize behavior.

## Migration 

- Once https://github.com/artsy/substance/pull/169 is merged and the nginx ingress is provisioned on production merge this PR
- Update `developers.artsy.net` in Cloudflare to the DNS address of the production nginx ingress NLB (staging is `a005bff9daa5011ea976f123b14b93be-ce763f5e571815b5.elb.us-east-1.amazonaws.com`)
- Open another PR to change the service type from `LoadBalancer` to `ClusterIP`
