### PR TITLE
Update geckodriver for compatibility with recent Firefox versions

### DIFF
--- a/script/ci.sh
+++ b/script/ci.sh
@@ -1,7 +1,7 @@
 #!/bin/sh
 
 set +x
-wget https://github.com/mozilla/geckodriver/releases/download/v0.18.0/geckodriver-v0.18.0-linux64.tar.gz -O /tmp/geckodriver.tar.gz && \
+wget https://github.com/mozilla/geckodriver/releases/download/v0.26.0/geckodriver-v0.26.0-linux64.tar.gz -O /tmp/geckodriver.tar.gz && \
   tar xvf /tmp/geckodriver.tar.gz -C /opt && \
   ln -fs /opt/geckodriver /usr/bin/geckodriver
 


### PR DESCRIPTION
The `ci.sh` script installs the _latest_ Firefox (currently `68.9.0esr`), but an old version of `geckodriver`. Locally, tests seemed to hang until I killed them after a few minutes. Once upgraded, `hokusai test` succeeded.

This version compatibility chart was helpful: https://firefox-source-docs.mozilla.org/testing/geckodriver/Support.html#supported-platforms