### PR TITLE
change LoadBalancer to ClusterIP service in production

### DIFF
--- a/hokusai/production.yml
+++ b/hokusai/production.yml
@@ -53,6 +53,7 @@ spec:
                   operator: In
                   values:
                     - foreground
+
 ---
 apiVersion: v1
 kind: Service
@@ -63,18 +64,8 @@ metadata:
     layer: application
   name: doppler-web
   namespace: default
-  annotations:
-    service.beta.kubernetes.io/aws-load-balancer-ssl-cert: {{ artsyNetWildcardSSLCert }}
-    service.beta.kubernetes.io/aws-load-balancer-backend-protocol: "http"
-    service.beta.kubernetes.io/aws-load-balancer-ssl-ports: "443"
-    service.beta.kubernetes.io/aws-load-balancer-cross-zone-load-balancing-enabled: "true"
-    service.beta.kubernetes.io/aws-load-balancer-connection-draining-enabled: "true"
 spec:
   ports:
-    - port: 443
-      protocol: TCP
-      name: https
-      targetPort: 8080
     - port: 80
       protocol: TCP
       name: http
@@ -83,8 +74,7 @@ spec:
     app: doppler
     layer: application
     component: web
-  sessionAffinity: None
-  type: LoadBalancer
+  type: ClusterIP
 
 ---
 apiVersion: extensions/v1beta1


### PR DESCRIPTION
Follow-up to https://github.com/artsy/doppler/pull/177

Changing the doppler-web service from LoadBalancer to ClusterIP should clean up the ELB