### PR TITLE
Temp fix for kubectl apply error related to changing service from loadbalancer to clusterip.

### DIFF
--- a/hokusai/production.yml
+++ b/hokusai/production.yml
@@ -70,6 +70,7 @@ spec:
       protocol: TCP
       name: http
       targetPort: 8080
+      nodePort: null
   selector:
     app: doppler
     layer: application

--- a/hokusai/staging.yml
+++ b/hokusai/staging.yml
@@ -71,6 +71,7 @@ spec:
       protocol: TCP
       name: http
       targetPort: 8080
+      nodePort: null
   selector:
     app: doppler
     layer: application


### PR DESCRIPTION
https://artsy.slack.com/archives/CA8SANW3W/p1592403810187300
https://github.com/kubernetes/kubectl/issues/221
https://artsyproduct.atlassian.net/browse/PLATFORM-2371

Error was:

```
#!/bin/bash -eo pipefail 
hokusai staging deploy $CIRCLE_SHA1 --update-config 
Deploying sha256:93c64c7cd746a6865e31b6eb2c5fbfc16ce611f717b20a3576f08dd8dd066778 to staging...
 

 
Patching Deployments in spec /root/project/hokusai/staging.yml with image digest sha256:93c64c7cd746a6865e31b6eb2c5fbfc16ce611f717b20a3576f08dd8dd066778
 

 
Applying patched spec /root/project/.hokusai-tmp/tmpbLYIkl...
 

 
deployment.extensions "doppler-web" configured
 
ingress.extensions "doppler" unchanged
 
The Service "doppler-web" is invalid: spec.ports[0].nodePort: Forbidden: may not be used when `type` is 'ClusterIP'
 
ERROR: Command 'kubectl --context staging apply -f /root/project/.hokusai-tmp/tmpbLYIkl' returned non-zero exit status 1
 
 
Exited with code exit status 1 
CircleCI received exit code 1 
```