### PR TITLE
#migration switch from doopler-web to doppler-web internal service

### DIFF
--- a/hokusai/production.yml
+++ b/hokusai/production.yml
@@ -62,15 +62,14 @@ metadata:
     app: doppler
     component: web
     layer: application
-  name: doppler-web
+  name: doppler-web-internal
   namespace: default
 spec:
   ports:
-    - port: 80
+    - port: 8080
       protocol: TCP
       name: http
       targetPort: 8080
-      nodePort: null
   selector:
     app: doppler
     layer: application
@@ -89,5 +88,5 @@ spec:
         paths:
           - path: /
             backend:
-              serviceName: doppler-web
+              serviceName: doppler-web-internal
               servicePort: http

--- a/hokusai/staging.yml
+++ b/hokusai/staging.yml
@@ -63,15 +63,14 @@ metadata:
     app: doppler
     component: web
     layer: application
-  name: doppler-web
+  name: doppler-web-internal
   namespace: default
 spec:
   ports:
-    - port: 80
+    - port: 8080
       protocol: TCP
       name: http
       targetPort: 8080
-      nodePort: null
   selector:
     app: doppler
     layer: application
@@ -90,5 +89,5 @@ spec:
         paths:
           - path: /
             backend:
-              serviceName: doppler-web
+              serviceName: doppler-web-internal
               servicePort: http


### PR DESCRIPTION
Following the pattern in https://github.com/artsy/horizon/pull/113 to migrate from *-web to *-web-internal services when adopting ingress resources.

## Migration

1) Deploy to create the doppler-web-internal service and update ingress resources to map to it

2) Delete the doppler-web service with `kubectl delete service doppler-web`