### PR TITLE
restrict ingress to cloudflare IP source ranges

### DIFF
--- a/hokusai/production.yml
+++ b/hokusai/production.yml
@@ -81,6 +81,8 @@ apiVersion: extensions/v1beta1
 kind: Ingress
 metadata:
   name: doppler
+  annotations:
+    nginx.ingress.kubernetes.io/whitelist-source-range: "{{ cloudflareIpSourceRanges|join(',') }}"
 spec:
   rules:
     - host: developers.artsy.net

--- a/hokusai/staging.yml
+++ b/hokusai/staging.yml
@@ -82,6 +82,8 @@ apiVersion: extensions/v1beta1
 kind: Ingress
 metadata:
   name: doppler
+  annotations:
+    nginx.ingress.kubernetes.io/whitelist-source-range: "{{ cloudflareIpSourceRanges|join(',') }}"
 spec:
   rules:
     - host: developers-staging.artsy.net


### PR DESCRIPTION
Forgot to add the Ingress annotation to restrict traffic to cloudflare IP source ranges as the application is proxied behind Cloudflare's WAF.