### PR TITLE
fix: replace docker-compose extends keyword with Jinja2 template

### DIFF
--- a/hokusai/build.yml
+++ b/hokusai/build.yml
@@ -2,5 +2,4 @@
 version: '2'
 services:
   doppler:
-    build:
-      context: ../
+{% include 'templates/docker-compose-service.yml.j2' %}

--- a/hokusai/development.yml
+++ b/hokusai/development.yml
@@ -3,9 +3,7 @@ version: '2'
 services:
   doppler:
     env_file: ../.env
-    extends:
-      file: build.yml
-      service: doppler
+{% include 'templates/docker-compose-service.yml.j2' %}
     ports:
       - 8080:8080
     volumes:

--- a/hokusai/templates/docker-compose-service.yml.j2
+++ b/hokusai/templates/docker-compose-service.yml.j2
@@ -1,0 +1,2 @@
+    build:
+      context: ../

--- a/hokusai/test.yml
+++ b/hokusai/test.yml
@@ -3,6 +3,4 @@ version: '2'
 services:
   doppler:
     command: ./script/ci.sh
-    extends:
-      file: build.yml
-      service: doppler
+{% include 'templates/docker-compose-service.yml.j2' %}


### PR DESCRIPTION
Required for Docker Compose v3 / Hokusai >= v0.5.12 compatibility