### PR TITLE
Rename main branch from master to main

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -10,11 +10,11 @@ not_staging_or_release: &not_staging_or_release
         - staging
         - release
 
-only_master: &only_master
+only_main: &only_main
   context: hokusai
   filters:
     branches:
-      only: master
+      only: main
 
 only_release: &only_release
   context: hokusai
@@ -30,12 +30,12 @@ workflows:
 
       - hokusai/push:
           name: push-staging-image
-          <<: *only_master
+          <<: *only_main
           requires:
             - hokusai/test
 
       - hokusai/deploy-staging:
-          <<: *only_master
+          <<: *only_main
           project-name: 'doppler'
           requires:
             - push-staging-image

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -18,8 +18,8 @@ git remote add upstream https://github.com/artsy/doppler.git
 Make sure your fork is up-to-date and create a topic branch for your feature or bug fix.
 
 ```
-git checkout master
-git pull upstream master
+git checkout main
+git pull upstream main
 git checkout -b my-feature-branch
 ```
 
@@ -96,11 +96,11 @@ Go to https://github.com/contributor/doppler and select your feature branch. Cli
 
 #### Rebase
 
-If you've been working on a change for a while, rebase with upstream/master.
+If you've been working on a change for a while, rebase with upstream/main.
 
 ```
 git fetch upstream
-git rebase upstream/master
+git rebase upstream/main
 git push origin my-feature-branch -f
 ```
 


### PR DESCRIPTION
This updates CI and docs to use `main` instead of `master`. I used [this playbook](https://github.com/artsy/README/blob/main/playbooks/rename-master-to-main.md), plus full-text searching. I'll self-merge to monitor that the main build and staging deploy work as expected, but feedback welcome.


In case anyone encounters `hokusai` errors that mention the `master` branch, like:

```
hokusai staging update --dry-run
ERROR: Not on master branch!  Aborting.
```

You can pass a `--check-branch` option:
```
hokusai staging update --dry-run --check-branch main
Updated Kubernetes environment ... (dry run)
```