### PR TITLE
feat: Adds GravityV1 client and allow to GET client application partners, with configuration fix for staging envs

### DIFF
--- a/app/assets/stylesheets/client_application_partners.css
+++ b/app/assets/stylesheets/client_application_partners.css
@@ -1,0 +1,1 @@
+/* placeholder */

--- a/app/controllers/client_application_partners_controller.rb
+++ b/app/controllers/client_application_partners_controller.rb
@@ -1,0 +1,29 @@
+class ClientApplicationPartnersController < ApplicationController
+  def index
+    client_application_id = params[:client_application_id]
+    response = ClientApplicationPartnerService.fetch_partners(client_application_id, session[:access_token])
+
+    # Convert each response hash into a ClientApplicationPartner object
+    @client_application_partners = response.map do |partner_data|
+      build_client_application_partner(partner_data)
+    end
+  rescue => e
+    @error = e.message
+  end
+
+  private
+
+  def build_client_application_partner(data)
+    ClientApplicationPartner.new(
+      id: data[:id],
+      partner_id: data[:partner_id],
+      client_application_id: data[:client_application_id],
+      created_at: data[:created_at],
+      updated_at: data[:updated_at]
+    )
+  end
+
+  def client_application_partner_params
+    params.require(:client_application_partner).permit(:client_application_id, :partner_id)
+  end
+end

--- a/app/helpers/artsy_api/v1.rb
+++ b/app/helpers/artsy_api/v1.rb
@@ -1,3 +1,6 @@
+# TODO: Future cleanup, this class only fetches the docs url and data for the API playground
+# Slightly different from a library client
+
 module ArtsyApi
   module V1
     def self.url

--- a/app/models/client_application_partner.rb
+++ b/app/models/client_application_partner.rb
@@ -1,0 +1,5 @@
+class ClientApplicationPartner
+  include ActiveModel::Model
+
+  attr_accessor :id, :client_application_id, :partner_id, :created_at, :updated_at
+end

--- a/app/services/client_application_partner_service.rb
+++ b/app/services/client_application_partner_service.rb
@@ -1,0 +1,6 @@
+class ClientApplicationPartnerService
+  def self.fetch_partners(client_application_id, access_token)
+    url = "#{Gravity::GRAVITY_V1_API_URL}/client_application/#{client_application_id}/client_application_partners"
+    Gravity.get(url: url, additional_headers: {"X-Access-Token" => access_token})
+  end
+end

--- a/app/views/client_application_partners/index.html.haml
+++ b/app/views/client_application_partners/index.html.haml
@@ -1,0 +1,26 @@
+%h1 My Configured Partners
+
+- if !@client_application_partners
+
+  .alert.alert-danger
+    There was an error retrieving applications: #{@error}.
+
+- elsif @client_application_partners.any?
+
+  %table.table.table-bordered.table-striped
+    %thead
+      %tr
+        %th ID
+        %th Client Application ID
+        %th Partner ID
+        %th Created
+        %th Last Updated At
+
+    %tbody.applications
+      - @client_application_partners.each do |client_application_partner|
+        %tr
+          %td.id= client_application_partner.id
+          %td.client_application_id= client_application_partner.client_application_id
+          %td.partner_id= client_application_partner.partner_id
+          %td.created_at= DateTime.parse(client_application_partner.created_at).strftime("%B %d, %Y")
+          %td.updated_at= DateTime.parse(client_application_partner.updated_at).strftime("%B %d, %Y")

--- a/config/application.rb
+++ b/config/application.rb
@@ -31,5 +31,6 @@ module Doppler
     #
     # config.time_zone = "Central Time (US & Canada)"
     # config.eager_load_paths << Rails.root.join("extras")
+    config.eager_load_paths += Dir[Rails.root.join("lib")]
   end
 end

--- a/config/gravity.yml
+++ b/config/gravity.yml
@@ -5,5 +5,7 @@ test:
   <<: *default
   api_root: "http://doppler-test.test.net"
   api_v1_root: "http://doppler-test.test.net/api/v1"
+staging:
+  <<: *default
 production:
   <<: *default

--- a/config/gravity.yml
+++ b/config/gravity.yml
@@ -1,0 +1,9 @@
+development: &default
+  api_root: <%= "#{ENV['ARTSY_API_URL'] || 'https://stagingapi.artsy.net'}" %>
+  api_v1_root: <%= "#{ENV['ARTSY_API_URL'] || 'https://stagingapi.artsy.net'}/api/v1" %>
+test:
+  <<: *default
+  api_root: "http://doppler-test.test.net"
+  api_v1_root: "http://doppler-test.test.net/api/v1"
+production:
+  <<: *default

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,7 +1,9 @@
 Rails.application.routes.draw do
   root "welcome#index"
 
-  resources :client_applications
+  resources :client_applications do
+    resources :client_application_partners, only: [:index]
+  end
 
   mount ArtsyAuth::Engine => "/"
 

--- a/lib/gravity.rb
+++ b/lib/gravity.rb
@@ -1,0 +1,31 @@
+# API Client for Gravity V1
+class Gravity
+  class << self
+    GRAVITY_V1_API_URL = Rails.application.config_for(:gravity)["api_v1_root"]
+
+    class GravityError < StandardError; end
+
+    class GravityNotFoundError < GravityError; end
+
+    def get(url:, additional_headers: {}, params: {})
+      response = Faraday.get(url, params, headers.merge(additional_headers))
+
+      process(response)
+    end
+
+    def process(response)
+      raise GravityNotFoundError if response.status == 404
+
+      results = JSON.parse(response.body, symbolize_names: true)
+      raise GravityError, "Couldn't perform request! status: #{response.status}. Message: #{results[:message]}" unless response.success?
+
+      results
+    end
+
+    private
+
+    def headers
+      {}
+    end
+  end
+end


### PR DESCRIPTION
Reimplements this [PR](https://github.com/artsy/doppler/pull/311)

Plus fixes missing Gravity config for staging environment that was missing in the first PR [here](https://github.com/artsy/doppler/pull/316/files#diff-5044a89c4bb8c0dcb5b4c1ae39553a3da72b320d9c83bc45e7da04ad6c39d7b4R8-R9)

You'll notice that Doppler is running Rails in staging mode and not the standard production mode
```
doppler % hokusai staging env get | grep RAILS
RAILS_ENV=staging
```


Which was causing the application to crash, You can see this locally by attempting to open up a rails console in staging mode:

```
doppler % RAILS_ENV=staging bundle exec rails c

dev/doppler/lib/gravity.rb:4:in `singleton class': undefined method `[]' for nil:NilClass (NoMethodError)
```

With the fix, all is good:
```
doppler % RAILS_ENV=staging bundle exec rails c

irb(main):001:0> Rails.application.config_for(:gravity)["api_v1_root"]
=> "https://stagingapi.artsy.net/api/v1"
```
