### PR TITLE
fix: Fix extra nesting of readniessProbe config

### DIFF
--- a/hokusai/production.yml
+++ b/hokusai/production.yml
@@ -53,16 +53,16 @@ spec:
             memory: 800Mi
           limits:
             memory: 1Gi
-          readinessProbe:
-            httpGet:
-              port: doppler-http
-              path: /health/ping
-              httpHeaders:
-                - name: X-Forwarded-Proto
-                  value: https
-            initialDelaySeconds: 10
-            periodSeconds: 10
-            timeoutSeconds: 5
+        readinessProbe:
+          httpGet:
+            port: doppler-http
+            path: /health/ping
+            httpHeaders:
+              - name: X-Forwarded-Proto
+                value: https
+          initialDelaySeconds: 10
+          periodSeconds: 10
+          timeoutSeconds: 5
       dnsPolicy: ClusterFirst
       dnsConfig:
         options:

--- a/hokusai/staging.yml
+++ b/hokusai/staging.yml
@@ -53,16 +53,16 @@ spec:
             memory: 256Mi
           limits:
             memory: 500Mi
-          readinessProbe:
-            httpGet:
-              port: doppler-http
-              path: /health/ping
-              httpHeaders:
-                - name: X-Forwarded-Proto
-                  value: https
-            initialDelaySeconds: 10
-            periodSeconds: 10
-            timeoutSeconds: 5
+        readinessProbe:
+          httpGet:
+            port: doppler-http
+            path: /health/ping
+            httpHeaders:
+              - name: X-Forwarded-Proto
+                value: https
+          initialDelaySeconds: 10
+          periodSeconds: 10
+          timeoutSeconds: 5
       dnsPolicy: ClusterFirst
       dnsConfig:
         options:


### PR DESCRIPTION
Fix extra nesting of readniessProbe config

Error was being raised in CI here: https://app.circleci.com/pipelines/github/artsy/doppler/407/workflows/a6049326-6978-4329-a630-e8053a414742/jobs/541

This should fix it