### PR TITLE
fix: Fix access to URL constant

### DIFF
--- a/lib/gravity.rb
+++ b/lib/gravity.rb
@@ -1,8 +1,8 @@
 # API Client for Gravity V1
 class Gravity
-  class << self
-    GRAVITY_V1_API_URL = Rails.application.config_for(:gravity)["api_v1_root"]
+  GRAVITY_V1_API_URL = Rails.application.config_for(:gravity)["api_v1_root"]
 
+  class << self
     class GravityError < StandardError; end
 
     class GravityNotFoundError < GravityError; end


### PR DESCRIPTION
Fix for exception:

```
irb(main):001:0> Gravity::GRAVITY_V1_API_URL
(irb):1:in `<main>': uninitialized constant Gravity::GRAVITY_V1_API_URL (NameError)
```

Now should be readable like so:
```
irb(main):001:0> Gravity::GRAVITY_V1_API_URL
=> "https://stagingapi.artsy.net/api/v1"
```