### PR TITLE
WIP: Spike out Webhook Delivery show page to display full event payload

### DIFF
--- a/app/assets/javascripts/webhook_deliveries.js
+++ b/app/assets/javascripts/webhook_deliveries.js
@@ -1,0 +1,8 @@
+document.addEventListener('DOMContentLoaded', function() {
+  const rows = document.querySelectorAll('.clickable-row');
+  rows.forEach(row => {
+    row.addEventListener('click', () => {
+      window.location.href = row.getAttribute('data-url');
+    })
+  })
+})

--- a/app/assets/stylesheets/webhook_deliveries.css
+++ b/app/assets/stylesheets/webhook_deliveries.css
@@ -10,3 +10,12 @@
 .response-status-default {
   background-color: #f8f9fa;
 }
+
+table .clickable-row:hover {
+  box-shadow: 0px 4px 10px rgba(0, 0, 0, 0.1);
+  transform: scale(1.01);
+}
+
+.clickable-row {
+  cursor: pointer;
+}

--- a/app/controllers/webhook_deliveries_controller.rb
+++ b/app/controllers/webhook_deliveries_controller.rb
@@ -19,6 +19,32 @@ class WebhookDeliveriesController < ApplicationController
     @error = e.message
   end
 
+  def show
+    # TODO: unstub
+    @webhook_delivery = {"id" => "210e2eb8-af39-495f-baba-ca589860ea07",
+                         "created_at" => "2024-10-03T15:57:47.767Z",
+                         "completed_at" => "2024-10-08T10:57:46.741Z",
+                         "error_class" => nil,
+                         "response_status" => 200,
+                         "webhook_event" =>
+     {"created_at" => 1728403067,
+      "data" =>
+       {"sales_tax" => 10.0,
+        "artwork_id" => "1234",
+        "list_price" => 855.35,
+        "sale_price" => 755.35,
+        "external_id" => "4321",
+        "availability" => "sold",
+        "import_source" => "somewhere",
+        "price_display" => "exact",
+        "shipping_costs" => 90.0},
+      "id" => "a4ca6be7-2a86-4e5c-80de-988af1ae651a",
+      "name" => "artwork.order.approved",
+      "partner_id" => "1234"},
+                         "webhook_id" => "e01cd7e5-1a03-43a5-8463-a8dad1549e2a",
+                         "webhook_url" => "https://www.cool.com/endpoint"}.as_json
+  end
+
   private
 
   def build_webhook_delivery(data)

--- a/app/views/layouts/application.html.haml
+++ b/app/views/layouts/application.html.haml
@@ -2,6 +2,7 @@
 %html
   = render 'shared/header'
   = javascript_include_tag 'application'
+  = javascript_include_tag 'webhook_deliveries'
   %body
     #holder
       = render 'shared/nav'

--- a/app/views/webhook_deliveries/index.html.haml
+++ b/app/views/webhook_deliveries/index.html.haml
@@ -18,7 +18,7 @@
 
     %tbody.applications
       - @webhook_deliveries.each do |webhook_delivery|
-        %tr
+        %tr{ data: { url: client_application_webhook_delivery_path(params[:client_application_id], webhook_delivery.id) }, class: 'clickable-row' }
           %td.event_type= webhook_delivery.webhook_event.name
           %td.id= webhook_delivery.id
           %td.response_status{ class: status_class(webhook_delivery.response_status) }= webhook_delivery.response_status

--- a/app/views/webhook_deliveries/show.html.haml
+++ b/app/views/webhook_deliveries/show.html.haml
@@ -1,0 +1,92 @@
+%h1 Webhook Delivery Details
+
+-# TODO: Update this to deal with objects and not hashes
+
+= link_to "Back to Webhook List", client_application_webhook_deliveries_path(params[:client_application_id]), class: 'btn'
+
+%table.table.table-bordered
+  %tr
+    %th ID
+    %td= @webhook_delivery["id"]
+
+  %tr
+    %th Created At
+    %td= @webhook_delivery["created_at"]
+
+  %tr
+    %th Completed At
+    %td= @webhook_delivery["completed_at"]
+
+  %tr
+    %th Error Class
+    %td= @webhook_delivery["error_class"] || "None"
+
+  %tr
+    %th Response Status
+    %td= @webhook_delivery["response_status"]
+
+  %tr
+    %th Webhook ID
+    %td= @webhook_delivery["webhook_id"]
+
+  %tr
+    %th Webhook URL
+    %td= @webhook_delivery["webhook_url"]
+
+%h2 Webhook Event Details
+
+%table.table.table-bordered
+  %tr
+    %th Event Name
+    %td= @webhook_delivery["webhook_event"]["name"]
+
+  %tr
+    %th Event ID
+    %td= @webhook_delivery["webhook_event"]["id"]
+
+  %tr
+    %th Partner ID
+    %td= @webhook_delivery["webhook_event"]["partner_id"]
+
+  %tr
+    %th Created At
+    %td= @webhook_delivery["webhook_event"]["created_at"]
+
+%h2 Event Data
+
+%table.table.table-bordered
+  %tr
+    %th Sales Tax
+    %td= @webhook_delivery["webhook_event"]["data"]["sales_tax"]
+
+  %tr
+    %th Artwork ID
+    %td= @webhook_delivery["webhook_event"]["data"]["artwork_id"]
+
+  %tr
+    %th List Price
+    %td= @webhook_delivery["webhook_event"]["data"]["list_price"]
+
+  %tr
+    %th Sale Price
+    %td= @webhook_delivery["webhook_event"]["data"]["sale_price"]
+
+  %tr
+    %th External ID
+    %td= @webhook_delivery["webhook_event"]["data"]["external_id"]
+
+  %tr
+    %th Availability
+    %td= @webhook_delivery["webhook_event"]["data"]["availability"]
+
+  %tr
+    %th Import Source
+    %td= @webhook_delivery["webhook_event"]["data"]["import_source"]
+
+  %tr
+    %th Price Display
+    %td= @webhook_delivery["webhook_event"]["data"]["price_display"]
+
+  %tr
+    %th Shipping Costs
+    %td= @webhook_delivery["webhook_event"]["data"]["shipping_costs"]

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -3,7 +3,7 @@ Rails.application.routes.draw do
 
   resources :client_applications do
     resources :client_application_partners, only: [:index]
-    resources :webhook_deliveries, only: [:index]
+    resources :webhook_deliveries, only: [:index, :show]
   end
 
   mount ArtsyAuth::Engine => "/"


### PR DESCRIPTION
Build out `WebhookDelivery#show` functionality and display a page with full Webhook details, including event payload


Requires this API change from Gravity: https://github.com/artsy/gravity/pull/18225


Example experience:

https://github.com/user-attachments/assets/41a58ab9-a22b-4f0b-ad11-371b2be9248d

