### PR TITLE
chore: Allow Gravity client to surface headers (needed for pagination), slig…

### DIFF
--- a/app/controllers/client_application_partners_controller.rb
+++ b/app/controllers/client_application_partners_controller.rb
@@ -1,11 +1,17 @@
 class ClientApplicationPartnersController < ApplicationController
   def index
+    page = params[:page] || 1
+    size = params[:size] || 10
+
     client_application_id = params[:client_application_id]
     response = ClientApplicationPartnerService.fetch_partners(client_application_id, session[:access_token])
 
-    @client_application_partners = response.map do |partner_data|
+    @client_application_partners = response[:body].map do |partner_data|
       build_client_application_partner(partner_data)
     end
+
+    @total_pages = calculate_total_pages(response[:headers]["X-Total-Count"].to_i, size)
+    @current_page = page.to_i
   rescue => e
     @error = e.message
   end
@@ -22,6 +28,10 @@ class ClientApplicationPartnersController < ApplicationController
       created_at: data[:created_at],
       updated_at: data[:updated_at]
     )
+  end
+
+  def calculate_total_pages(total_records, size)
+    (total_records / size.to_f).ceil
   end
 
   def client_application_partner_params

--- a/app/controllers/client_application_partners_controller.rb
+++ b/app/controllers/client_application_partners_controller.rb
@@ -1,8 +1,6 @@
 class ClientApplicationPartnersController < ApplicationController
+  include Paginatable
   def index
-    page = params[:page] || 1
-    size = params[:size] || 10
-
     client_application_id = params[:client_application_id]
     response = ClientApplicationPartnerService.fetch_partners(client_application_id, session[:access_token])
 
@@ -10,8 +8,8 @@ class ClientApplicationPartnersController < ApplicationController
       build_client_application_partner(partner_data)
     end
 
-    @total_pages = calculate_total_pages(response[:headers]["X-Total-Count"].to_i, size)
-    @current_page = page.to_i
+    @total_pages = calculate_total_pages(response[:headers]["X-Total-Count"].to_i, @size)
+    @current_page = @page.to_i
   rescue => e
     @error = e.message
   end
@@ -28,10 +26,6 @@ class ClientApplicationPartnersController < ApplicationController
       created_at: data[:created_at],
       updated_at: data[:updated_at]
     )
-  end
-
-  def calculate_total_pages(total_records, size)
-    (total_records / size.to_f).ceil
   end
 
   def client_application_partner_params

--- a/app/controllers/concerns/paginatable.rb
+++ b/app/controllers/concerns/paginatable.rb
@@ -1,0 +1,16 @@
+module Paginatable
+  extend ActiveSupport::Concern
+
+  included do
+    before_action :set_pagination
+  end
+
+  def set_pagination
+    @page = params[:page] || 1
+    @size = params[:size] || 10
+  end
+
+  def calculate_total_pages(total_records, size)
+    (total_records / size.to_f).ceil
+  end
+end

--- a/app/controllers/webhook_deliveries_controller.rb
+++ b/app/controllers/webhook_deliveries_controller.rb
@@ -1,37 +1,34 @@
 class WebhookDeliveriesController < ApplicationController
+  before_action :set_client_application_id, :set_access_token
+
   def index
     page = params[:page] || 1
     size = params[:size] || 10
-    client_application_id = params[:client_application_id]
 
-    cache_key = "webhook_deliveries/#{client_application_id}/page/#{page}/size/#{size}"
+    cache_key = "webhook_deliveries/#{@client_application_id}/page/#{page}/size/#{size}"
 
     # Use Rails.cache to cache the API response across requests
-    @webhook_deliveries = Rails.cache.fetch(cache_key, expires_in: 10.minutes) do
-      response = ClientApplicationService.fetch_webhook_deliveries(
-        session[:access_token],
-        client_application_id: client_application_id, page: page, size: size
-      )
-
-      response.map do |webhook_delivery_data|
-        build_webhook_delivery(webhook_delivery_data)
-      end
+    response = Rails.cache.fetch(cache_key, expires_in: 10.minutes) do
+      fetch_webhook_deliveries(page, size)
     end
 
-    @total_pages = 1 # FIX ME: response.headers["X-Total-Count"]
+    @webhook_deliveries = response[:body].map do |webhook_delivery_data|
+      build_webhook_delivery(webhook_delivery_data)
+    end
+
+    @total_pages = calculate_total_pages(response[:headers]["X-Total-Count"].to_i, size)
     @current_page = page.to_i
   rescue => e
     @error = e.message
   end
 
   def show
-    webhook_delivery_id = params[:id]
     response = ClientApplicationService.fetch_webhook_delivery(
-      session[:access_token],
-      id: webhook_delivery_id
+      @access_token,
+      id: params[:id]
     )
 
-    @webhook_delivery = build_webhook_delivery(response)
+    @webhook_delivery = build_webhook_delivery(response[:body])
   rescue => e
     @error = e.message
   end
@@ -49,6 +46,30 @@ class WebhookDeliveriesController < ApplicationController
       webhook_id: data[:webhook_id],
       webhook_url: data[:webhook_url]
     )
+  end
+
+  def calculate_total_pages(total_records, size)
+    (total_records / size.to_f).ceil
+  end
+
+  def fetch_webhook_deliveries(page, size)
+    response = ClientApplicationService.fetch_webhook_deliveries(
+      @access_token,
+      client_application_id: @client_application_id,
+      page: page,
+      size: size,
+      total_count: true
+    )
+
+    {body: response[:body], headers: response[:headers]}
+  end
+
+  def set_client_application_id
+    @client_application_id = params[:client_application_id]
+  end
+
+  def set_access_token
+    @access_token = session[:access_token]
   end
 
   def client_application_partner_params

--- a/app/views/client_application_partners/index.html.haml
+++ b/app/views/client_application_partners/index.html.haml
@@ -28,3 +28,7 @@
           %td.partner_id= client_application_partner.partner_id
           %td.created_at= DateTime.parse(client_application_partner.created_at).strftime("%B %d, %Y")
           %td.updated_at= DateTime.parse(client_application_partner.updated_at).strftime("%B %d, %Y")
+
+
+  = link_to 'Previous', client_application_webhook_deliveries_path(page: @current_page - 1) if @current_page > 1
+  = link_to 'Next', client_application_webhook_deliveries_path(page: @current_page + 1) if @current_page < @total_pages

--- a/lib/gravity.rb
+++ b/lib/gravity.rb
@@ -19,7 +19,8 @@ class Gravity
       results = JSON.parse(response.body, symbolize_names: true)
       raise GravityError, "Couldn't perform request! status: #{response.status}. Message: #{results[:message]}" unless response.success?
 
-      results
+      # Return both headers and body as part of the response
+      {body: results, headers: response.headers}
     end
 
     private

--- a/lib/gravity.rb
+++ b/lib/gravity.rb
@@ -19,8 +19,8 @@ class Gravity
       results = JSON.parse(response.body, symbolize_names: true)
       raise GravityError, "Couldn't perform request! status: #{response.status}. Message: #{results[:message]}" unless response.success?
 
-      # Return both headers and body as part of the response
-      {body: results, headers: response.headers}
+      # Return both the body and only the `X-Total-Count` header part of the response
+      {body: results, headers: {"X-Total-Count" => response.headers["X-Total-Count"]}}
     end
 
     private


### PR DESCRIPTION
…ht refactor

Actually implements parsing the headers from Gravity's API call to see how we want to paginate records, we need the value of `headers['x-total-count']` from Gravity's V1 response to tell us when to expect the need to paginate



Adjusts the `Gravity` client to return both a parsed body and headers in a hash:
```ruby
def process(response)
  raise GravityNotFoundError if response.status == 404

  results = JSON.parse(response.body, symbolize_names: true)
  raise GravityError, "Couldn't perform request! status: #{response.status}. Message: #{results[:message]}" unless response.success?

  # Return both headers and body as part of the response
  {body: results, headers: response.headers}
end
```

## Example
Example of pagination working (limited it to one record per page where `headers['x-total-count'] is 3`:

https://github.com/user-attachments/assets/d00f17ee-c4cd-4c3e-8516-94d206348f7b



## Heads up!
I understand there is a lot of handwritten pagination logic going on here, we can hopefully refactor to be handled more globally as we retire `GravityV2` hypermedia API usage here
