### PR TITLE
feat: Allowing clients to attempt webhook redelivery

### DIFF
--- a/app/controllers/webhook_deliveries_controller.rb
+++ b/app/controllers/webhook_deliveries_controller.rb
@@ -31,6 +31,21 @@ class WebhookDeliveriesController < ApplicationController
     @error = e.message
   end
 
+  def redeliver
+    response = ClientApplicationService.redeliver_webhook_delivery(
+      @access_token,
+      id: params[:id]
+    )
+
+    if response[:body][:status] == "success"
+      flash[:notice] = "Webhook redelivery initiated successfully."
+    else
+      flash[:alert] = "Failed to redeliver the webhook event: #{response[:error]}"
+    end
+
+    redirect_back(fallback_location: client_application_webhook_delivery_path(params[:client_application_id], params[:id]))
+  end
+
   private
 
   def build_webhook_delivery(data)

--- a/app/services/client_application_service.rb
+++ b/app/services/client_application_service.rb
@@ -8,4 +8,9 @@ class ClientApplicationService
     url = "#{Gravity::GRAVITY_V1_API_URL}/webhook_delivery/#{params[:id]}"
     Gravity.get(url: url, additional_headers: {"X-Access-Token" => access_token}, params: params)
   end
+
+  def self.redeliver_webhook_delivery(access_token, params = {})
+    url = "#{Gravity::GRAVITY_V1_API_URL}/webhook_delivery/#{params[:id]}/redeliver"
+    Gravity.post(url: url, additional_headers: {"X-Access-Token" => access_token}, params: params)
+  end
 end

--- a/app/views/webhook_deliveries/index.html.haml
+++ b/app/views/webhook_deliveries/index.html.haml
@@ -15,6 +15,7 @@
         %th Error Class
         %th Created At
         %th Completed At
+        %th &nbsp;
 
     %tbody.applications
       - @webhook_deliveries.each do |webhook_delivery|
@@ -25,6 +26,9 @@
           %td.error_class= webhook_delivery.error_class
           %td.created_at= webhook_delivery.created_at && DateTime.parse(webhook_delivery.created_at).strftime("%B %d, %Y")
           %td.completed_at= webhook_delivery.completed_at && DateTime.parse(webhook_delivery.completed_at).strftime("%B %d, %Y")
+          %td.actions
+            = link_to 'Redeliver', redeliver_client_application_webhook_delivery_path(params[:client_application_id], webhook_delivery.id), method: :post, data: { confirm: "Are you sure?" }, class: 'btn btn-primary'
+
 
 
   = link_to 'Previous', client_application_webhook_deliveries_path(page: @current_page - 1) if @current_page > 1

--- a/app/views/webhook_deliveries/show.html.haml
+++ b/app/views/webhook_deliveries/show.html.haml
@@ -35,6 +35,13 @@
       %th Configured Webhook Endpoint URL
       %td= @webhook_delivery.webhook_url
 
+    %tr
+      %th Redeliver
+      %td.actions
+        = link_to 'Redeliver', redeliver_client_application_webhook_delivery_path(params[:client_application_id], @webhook_delivery.id), method: :post, data: { confirm: "Are you sure?" }, class: 'btn btn-primary'
+
+
+
   %h2 Webhook Event Payload
 
   %pre

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -3,7 +3,11 @@ Rails.application.routes.draw do
 
   resources :client_applications do
     resources :client_application_partners, only: [:index]
-    resources :webhook_deliveries, only: [:index, :show]
+    resources :webhook_deliveries, only: [:index, :show] do
+      member do
+        post :redeliver
+      end
+    end
   end
 
   mount ArtsyAuth::Engine => "/"

--- a/lib/gravity.rb
+++ b/lib/gravity.rb
@@ -13,6 +13,12 @@ class Gravity
       process(response)
     end
 
+    def post(url:, additional_headers: {}, params: {})
+      response = Faraday.post(url, params, headers.merge(additional_headers))
+
+      process(response)
+    end
+
     def process(response)
       raise GravityNotFoundError if response.status == 404
 


### PR DESCRIPTION
Allow clients to trigger Webhook redeliveries from the webhooks list log and show page

Powered by the Gravity level changes [here](https://github.com/artsy/gravity/pull/18277)

## Example of the behavior 
(Dont mind the error status on the new webhook deliveries too much here it is trying to post a webhook event to `https://cool.com` 😉 )

https://github.com/user-attachments/assets/9dc18210-cc41-40cf-b7f8-2f2fafdf2bf5


