### PR TITLE
chore: Set exact Rails version in Gemfile

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -2,6 +2,8 @@ source "https://rubygems.org"
 
 ruby "3.3.0"
 
+gem "rails", "7.1.4.1"
+
 gem "artsy-auth"
 gem "bootstrap_form"
 gem "coderay"
@@ -18,7 +20,6 @@ gem "jquery-rails"
 gem "nokogiri"
 gem "oauth2", "1.4.9"
 gem "puma"
-gem "rails", "~> 7.0"
 gem "redcarpet"
 gem "redis-rails"
 gem "sass-rails"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -485,7 +485,7 @@ DEPENDENCIES
   nokogiri
   oauth2 (= 1.4.9)
   puma
-  rails (~> 7.0)
+  rails (= 7.1.4.1)
   redcarpet
   redis-rails
   rspec-rails


### PR DESCRIPTION
This PR does two very nit-picky things:

* pulls out the rails gem into it's own section towards the top
* sets the exact Rails version

Mostly this is to keep things more consistent in our Rails apps but it also makes the `artsy_ruby_doctor` project work correctly - otherwise I end up thinking this project is on a Rails 7.0 version!

/cc @artsy/amber-devs