### PR TITLE
feat: migrate ingress to new controllers (staging)

### DIFF
--- a/hokusai/staging.yml
+++ b/hokusai/staging.yml
@@ -129,11 +129,11 @@ spec:
 apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
-  name: doppler
+  name: doppler-2025
   annotations:
     nginx.ingress.kubernetes.io/whitelist-source-range: {{ cloudflareIpSourceRanges|join(',') }}
 spec:
-  ingressClassName: nginx
+  ingressClassName: external-nginx
   rules:
   - host: developers-staging.artsy.net
     http:


### PR DESCRIPTION
The existing ingress controllers are not scalable. We have [created a new set of Ingress Controllers](https://github.com/artsy/substance/pull/420) that are scalable.

This PR migrates ingresses to the new controllers, without disrupting traffic.

Migration:
---
- [x] Merge PR and wait for staging deployment to finish.
- [ ] Point the app's external DNS (if any) to the new controllers (`nginx-staging-2025.artsy.net`). This should be done via Infrastructure repo if the record is managed there.
- [x] Point the app's internal DNS (if any) to the new controllers (`nginx-2025.stg.artsy.systems`). This should be done via Substance repo if the record is managed there.
- [ ] Verify that the app still works.
- [ ] Wait 1 day.
- [ ] Delete the old ingress via kubectl. (`kubectl --context staging delete ingress <old-ingress-name>`)