### PR TITLE
Migrate from asdf to mise

### DIFF
--- a/bin/setup
+++ b/bin/setup
@@ -6,17 +6,11 @@
 # Exit if any subcommand fails
 set -e
 
-if command -v asdf >/dev/null; then
-  echo "Installing language dependencies with asdf"
-  asdf install
-  # Initialize asdf and ensure it switches to the right Ruby version
-  . ~/.asdf/asdf.sh
-  asdf reshim
-  # Pull the Ruby version from .tool-versions file
-  RUBY_VERSION=$(awk '/ruby/ {print $2}' .tool-versions)
-  asdf shell ruby $RUBY_VERSION
+if command -v mise >/dev/null; then
+  echo "Installing language dependencies with mise"
+  mise install
 else
-  echo "Skipping language dependencies installation (asdf not found)"
+  echo "Skipping language dependencies installation (mise not found)"
 fi
 
 echo "Downloading .env.shared (for common local dev config)..."


### PR DESCRIPTION
## Summary
- Replace `asdf` with `mise` in setup script
- Remove asdf-specific logic (reshim, shell initialization)
- Maintain compatibility with existing `.tool-versions` files

## Changes
- Replace `if command -v asdf` with `if command -v mise`
- Replace `asdf install` with `mise install`
- Remove asdf-specific commands: `asdf reshim`, shell initialization, and version switching
- Update echo messages to reference mise instead of asdf

mise handles version switching automatically, so the additional asdf commands are no longer needed.
This migration maintains full compatibility with existing `.tool-versions` files, which work with both asdf and mise.

Related to RFC: https://github.com/artsy/README/issues/550

🤖 Generated with [Claude Code](https://claude.ai/code)