### PR TITLE
chore: remove date from retirement notice

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ I am Doppler, the Artsy developer website.
 
 Please note, we are in the process of retiring the [public api.](developers.artsy.net/v2).
 
-The public api, as well as its documentation and playground, will remain available until **July 28th, 2025.**
+The public api, as well as its documentation and playground, may be taken down at any time without additional notice.
 
 This change will not affect partners currently using our [partner api.](developers.artsy.net/v1).
 

--- a/app/views/shared/_nav.html.haml
+++ b/app/views/shared/_nav.html.haml
@@ -18,8 +18,7 @@
     %p
       Please note, we are in the process of retiring the
       = link_to 'public api.', '/v2'
-      The public api, as well as its documentation and playground, will remain available until
-      %strong July 28th, 2025.
+      The public api, as well as its documentation and playground, may be taken down at any time without additional notice.
       This change will not affect integration partners using our
       = link_to 'partner api.', '/v1'
     %br/


### PR DESCRIPTION
Minor house keeping PR to update the copy of our retirement notice. We've long passed the original date, so this serves to note that we may take it down at any time.

<img width="1242" height="525" alt="Screenshot 2025-12-10 at 4 37 25 PM" src="https://github.com/user-attachments/assets/2c5ac725-d5f9-4196-902a-bd5663514a44" />
